### PR TITLE
Patch supermini

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -155,6 +155,35 @@ board_build.partitions = part32.csv
 board_build.filesystem = littlefs 
 board_build.embed_txtfiles = ${common_env_data.html_files}
 
+[env:gravity32c3SuperMini-release]							#D Ashmore new environment for super mini board
+framework = arduino
+platform = ${common_env_data.platform32}
+upload_speed = ${common_env_data.upload_speed}
+monitor_speed = ${common_env_data.monitor_speed}
+extra_scripts = ${common_env_data.extra_scripts}
+build_unflags =
+	${common_env_data.build_unflags}
+build_flags =
+	-Wl,-Map,output.map
+	${common_env_data.build_flags}
+	-D LOG_LEVEL=5
+	#-D CORE_DEBUG_LEVEL=6
+	-D ESP32C3
+	-D ARDUINO_ESP32C3_DEV
+	#-D ESPFWK_DISABLE_LED									# D Ashmore re-enable LED for super mini board
+	#-D ARDUINO_USB_CDC_ON_BOOT=1
+	#-DUSE_SERIAL_PINS # Use the TX/RX pins for the serial port
+lib_deps =
+	${common_env_data.lib_deps}
+	${common_env_data.lib_deps32}
+	${common_env_data.lib_ble32}
+lib_ignore =
+board = super_mini_esp32c3									# D Ashmore define super mini board
+build_type = release
+board_build.partitions = part32.csv
+board_build.filesystem = littlefs
+board_build.embed_txtfiles = ${common_env_data.html_files}
+
 [env:gravity32s2-release]
 framework = arduino
 platform = ${common_env_data.platform32}


### PR DESCRIPTION
Update to platformio.ini to allow the ESP32C3 SuperMini board to work along with the onboard blue LED.

The following Files were added to the .platformio folder:-

1)  in folder ~/.platformio/packages/framework-arduinoespressif32/variants/super_mini_esp32c3

[pins.arduino_super_mni_esp32c3.zip](https://github.com/user-attachments/files/18363959/pins.arduino_super_mini_esp32c3.zip) 

2) in folder ~/.platformio/platforms/espressif32/boards

[super_mini_esp32c3.json](https://github.com/user-attachments/files/18364032/super_mini_esp32c3.json)

On the original Ispindel board the super mini board is small enough to be stuck onto the board by double sided 3M Pads and fly wired to the correct connections.
I have a PCB available on PCBWay.com mainly intended for the Rapt Pill housing but should also fit the ISpindel tube.
