### PR TITLE
Multi-IMU support and ICM compatibility

### DIFF
--- a/src/ICM42670pGyro.cpp
+++ b/src/ICM42670pGyro.cpp
@@ -1,0 +1,411 @@
+/*
+MIT License
+
+Copyright (c) 2021-2024 Magnus
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
+#include <ICM42670pGyro.hpp>
+#include <I2Cdev.h>
+#include <log.hpp>
+#include <main.hpp>
+
+ICM42670pGyro icmGyro;
+
+#define USE_FIFO_MODE true
+
+#define INT16_FROM_BUFFER(high, low) (int16_t)((((int16_t)buffer[high]) << 8) | buffer[low])
+#define UINT16_FROM_BUFFER(high, low) (uint16_t)((((uint16_t)buffer[high]) << 8) | buffer[low])
+
+#define ICM42670_PRIMARY_ADDRESS 0x68
+#define ICM42670_SECONDARY_ADDRESS 0x69
+#define ICM42670_WHOAMI_REGISTER 0x75
+#define ICM42670_WHOAMI_VALUE 0x67
+#define ICM42670_FLUSH_REGISTER 0x75
+#define ICM42670_FLUSH_VALUE 0x67
+#define ICM42670_PWR_MGMT0_REGISTER 0x1F
+
+bool ICM42670pGyro::isOnline()
+{
+  if (I2Cdev::readByte(ICM42670_PRIMARY_ADDRESS, ICM42670_WHOAMI_REGISTER, buffer) == 1 && buffer[0] == ICM42670_WHOAMI_VALUE)
+  {
+    addr = ICM42670_PRIMARY_ADDRESS;
+    return true;
+  }
+  if (I2Cdev::readByte(ICM42670_SECONDARY_ADDRESS, ICM42670_WHOAMI_REGISTER, buffer) == 1 && buffer[0] == ICM42670_WHOAMI_VALUE)
+  {
+    addr = ICM42670_SECONDARY_ADDRESS;
+    return true;
+  }
+  return false;
+}
+
+bool ICM42670pGyro::writeMBank1(uint8_t reg, uint8_t value)
+{
+  bool status = true;
+  status &= I2Cdev::writeByte(addr, 0x79, 0);
+  status &= I2Cdev::writeByte(addr, 0x7A, reg);
+  status &= I2Cdev::writeByte(addr, 0x7B, value);
+  delayMicroseconds(10);
+  return status;
+}
+
+bool ICM42670pGyro::readMBank1(uint8_t reg)
+{
+  bool status = true;
+  status &= I2Cdev::writeByte(addr, 0x7C, 0);
+  status &= I2Cdev::writeByte(addr, 0x7D, reg);
+  delayMicroseconds(10);
+  status &= I2Cdev::readByte(addr, 0x7E, buffer);
+  delayMicroseconds(10);
+  return status;
+}
+
+bool ICM42670pGyro::writeMBank1AndVerify(uint8_t reg, uint8_t value)
+{
+  int i = 0;
+  buffer[0] = 0;
+  while (i < 5)
+  {
+    auto status = true;
+    status &= writeMBank1(reg, value);
+    status &= readMBank1(reg);
+    if (!status || buffer[0] != value)
+    {
+      // the only reason this occurs is if the IC is still booting after reset or poweron
+      // and comms are up but the ic is not actually running correctly
+      // only way to fix is no comms for 1s and try again
+      delay(1000);
+      i++;
+    }
+    else
+    {
+      return true;
+    }
+  }
+  return false;
+}
+
+uint8_t getNextPowerOf2(int n)
+{
+  int k = 0;
+  while (n > (1 << k) && k < 8)
+    k++;
+  return k;
+}
+
+uint8_t getDecimationValue(uint8_t p)
+{
+  // 0 = /1
+  // 8 = /2
+  // 9 = /4
+  //...
+  // 15 = /256
+  if (p == 0)
+  {
+    return 0;
+  }
+  return min(7 + p, 15);
+}
+
+bool ICM42670pGyro::setup()
+{
+#if LOG_LEVEL == 6
+  Log.verbose(F("ICM : Starting ICM setup" CR));
+#endif
+#if USE_FIFO_MODE
+  if (I2Cdev::readByte(addr, ICM42670_PWR_MGMT0_REGISTER, buffer) == 1 && buffer[0] == 0x0F)
+  {
+    // ICM is already configured = OK
+#if LOG_LEVEL == 6
+    Log.info(F("ICM : Setup OK" CR));
+#endif
+    _sensorConnected = true;
+    return true;
+  }
+  else
+  {
+    // first time setup or comm faillure
+    // start oscillator
+    if (!I2Cdev::writeByte(addr, 0x1F, 0x10))
+    {
+      Log.error(F("ICM : Start OSC failed" CR));
+      return false;
+    }
+    // wait until oscillator is ok, this takes only 1 or 2 comms
+    while (I2Cdev::readByte(addr, 0x00, buffer) && buffer[0] == 0)
+    {
+    }
+    // disable apex
+    if (!writeMBank1AndVerify(0x06, 0x40))
+    {
+      Log.error(F("ICM : Disable APEX failed" CR));
+      return false;
+    }
+    // calculate the Hz/fifo
+    auto sleep = myConfig.getSleepInterval();
+    // 80ms 2.25kB 2250B / 16B - 2 = 138 available packets
+    // 80m * 138=11s recording time without decimation
+    // select best decimation:
+    auto decimation = sleep / 11;
+    // round up to nearest possible value
+    auto power = getNextPowerOf2(decimation);
+    // get actual reg value
+    auto reg = getDecimationValue(power);
+#if LOG_LEVEL == 6
+    Log.verbose(F("ICM : Configuring decimation for %d" CR), sleep);
+    Log.verbose(F("ICM : decimation= %d" CR), decimation);
+    Log.verbose(F("ICM : power= %d" CR), power);
+    Log.verbose(F("ICM : reg= %d" CR), reg);
+#endif
+    // set fifo rate lower
+    if (!writeMBank1AndVerify(0x66, reg))
+    {
+      Log.error(F("ICM : Fifo rate set failed" CR));
+      return false;
+    }
+    // enable gyro+accel to go to fifo
+    if (!writeMBank1AndVerify(0x01, 0x03))
+    {
+      Log.error(F("ICM : Fifo output set failed" CR));
+      return false;
+    }
+    delayMicroseconds(10);
+    // disable watermark
+    I2Cdev::writeByte(addr, 0x29, 255);
+    I2Cdev::writeByte(addr, 0x2A, 255);
+    // set INTF_CONFIG0
+    if (!I2Cdev::writeByte(addr, 0x35, 0x70))
+    {
+      Log.error(F("ICM : Set INTF_CONFIG0 failed" CR));
+      return false;
+    }
+    // enable sensors
+    if (!I2Cdev::writeByte(addr, 0x1F, 0x0F))
+    {
+      Log.error(F("ICM : Sensor enable failed" CR));
+      return false;
+    }
+    delayMicroseconds(200); // mandatory per datasheet
+    // accel + gyro config @12.5 Hz
+    uint8_t config[5] = {0x6C, 0x6C, 0x70, 0x37, 0x47};
+    if (!I2Cdev::writeBytes(addr, 0x20, 5, config))
+    {
+      Log.error(F("ICM : Sensor config failed" CR));
+    }
+    // enable fifo
+    if (!I2Cdev::writeByte(addr, 0x28, 0x00))
+    {
+      Log.error(F("ICM : Fifo enable failed" CR));
+    }
+  }
+#else
+  // GYRO=LN ACCEL=LN
+  if (!I2Cdev::writeByte(addr, ICM42670_PWR_MGMT0_REGISTER, 0x0F))
+  {
+    return false;
+  }
+  configStart = millis();
+  delayMicroseconds(200); // mandatory per datasheet
+  // Original setup:
+  // GYRO=250dps GYRO=800Hz
+  // I2Cdev::writeByte(addr, 0x20, 0x66)
+  // ACCEL=2g ACCEL=800Hz
+  // I2Cdev::writeByte(addr, 0x21, 0x66)
+  // TEMP=4HzBW
+  // I2Cdev::writeByte(addr, 0x22, 0x70)
+  // GYRO=16HzBW
+  // I2Cdev::writeByte(addr, 0x23, 0x37)
+  // ACCEL=16HzBW
+  // I2Cdev::writeByte(addr, 0x24, 0x47)
+  uint8_t config[5] = {0x66, 0x66, 0x70, 0x37, 0x47};
+  if (
+      !I2Cdev::writeBytes(addr, 0x20, 5, config))
+  {
+    return false;
+  }
+#endif
+
+  _sensorConnected = true;
+  // we will not do calibration for now
+  // _calibrationOffset = myConfig.getGyroCalibration();
+  // applyCalibration();
+  return true;
+}
+
+void ICM42670pGyro::enterSleep()
+{
+#if !USE_FIFO_MODE
+  I2Cdev::writeByte(addr, ICM42670_PWR_MGMT0_REGISTER, 0x00);
+#endif
+}
+
+uint8_t ICM42670pGyro::ReadFIFOPackets(const uint16_t &count, RawGyroDataL &data)
+{
+  uint8_t success = 0;
+  Wire.beginTransmission(addr);
+  Wire.write(0x3F);
+  if (Wire.endTransmission() == 0)
+  {
+    uint8_t req = 0;
+    uint16_t total = 0;
+    while (count > total)
+    {
+      req = (uint8_t)min(count - total, 8);
+      if (Wire.requestFrom(addr, (size_t)(req * 16), (req == (count - total))) == req * 16)
+      {
+        while (Wire.available() >= 16)
+        {
+          Wire.readBytes(buffer, 16);
+
+          if ((buffer[0] & 0b11111100) == 0b01101000 && !isSensorMoving(INT16_FROM_BUFFER(7, 8), INT16_FROM_BUFFER(9, 10), INT16_FROM_BUFFER(11, 12)))
+          {
+            data.ax += INT16_FROM_BUFFER(1, 2);
+            data.ay += INT16_FROM_BUFFER(3, 4);
+            data.az += INT16_FROM_BUFFER(5, 6);
+            data.temp += (int8_t)buffer[13];
+            success++;
+          }
+        }
+      }
+      total += req;
+    }
+  }
+  return success;
+}
+
+GyroResultData ICM42670pGyro::readSensor()
+{
+  RawGyroDataL average = {0, 0, 0, 0, 0, 0};
+
+#if USE_FIFO_MODE
+  buffer[0] = 0;
+  buffer[1] = 0;
+  I2Cdev::readBytes(addr, 0x3D, 2, buffer);
+  uint16_t count = UINT16_FROM_BUFFER(0, 1);
+  count = min(count, (uint16_t)138);
+#if LOG_LEVEL == 6
+  Log.verbose(F("ICM : available packets= %d" CR), count);
+#endif
+  GyroResultData result = {false, _angle, _sensorTemp};
+  if (count > 0)
+  {
+    uint16_t valid = ReadFIFOPackets(count, average);
+
+    if (valid)
+    {
+      average.ax /= valid;
+      average.ay /= valid;
+      average.az /= valid;
+      float ax = (static_cast<float>(average.ax)) / 16384,
+            ay = (static_cast<float>(average.ay)) / 16384,
+            az = (static_cast<float>(average.az)) / 16384;
+      result.isValid = true;
+      if (result.isValid)
+      {
+        result.angle = calculateAngle(ax, ay, az);
+      }
+      result.temp = (static_cast<float>(average.temp)) / valid / 2 + 25;
+    }
+  }
+  return result;
+#else
+  int noIterations = myConfig.getGyroReadCount();
+  RawGyroData raw;
+  auto end = millis();
+  auto dur = end - configStart;
+  if (dur < 45)
+  {
+    delay(45 - dur);
+  }
+
+  for (int cnt = 0; cnt < noIterations; cnt++)
+  {
+    // INT_STATUS_DRDY
+    while (I2Cdev::readByte(addr, 0x36, buffer) == 0 || buffer[0] == 0)
+    {
+    }
+
+    I2Cdev::readBytes(addr, 0x09, 14, buffer);
+    raw.temp = (((int16_t)buffer[0]) << 8) | buffer[1];
+    raw.ax = (((int16_t)buffer[2]) << 8) | buffer[3];
+    raw.ay = (((int16_t)buffer[4]) << 8) | buffer[5];
+    raw.az = (((int16_t)buffer[6]) << 8) | buffer[7];
+    raw.gx = (((int16_t)buffer[8]) << 8) | buffer[9];
+    raw.gy = (((int16_t)buffer[10]) << 8) | buffer[11];
+    raw.gz = (((int16_t)buffer[12]) << 8) | buffer[13];
+
+    average.ax += raw.ax;
+    average.ay += raw.ay;
+    average.az += raw.az;
+    average.gx += raw.gx;
+    average.gy += raw.gy;
+    average.gz += raw.gz;
+    average.temp += raw.temp;
+  }
+
+  raw.ax = average.ax / noIterations;
+  raw.ay = average.ay / noIterations;
+  raw.az = average.az / noIterations;
+  raw.gx = average.gx / noIterations;
+  raw.gy = average.gy / noIterations;
+  raw.gz = average.gz / noIterations;
+  raw.temp = average.temp / noIterations;
+  GyroResultData result;
+  result.isValid = !isSensorMovingRaw(raw);
+  if (result.isValid)
+  {
+    result.angle = calculateAngleRaw(raw);
+  }
+  result.temp = (static_cast<float>(raw.temp)) / 340 + 36.53;
+  return result;
+#endif
+}
+
+void ICM42670pGyro::applyCalibration()
+{
+  // don't for now, these should be properly factory calibrated, any slight error during calibration will introduce more error
+}
+
+void ICM42670pGyro::calibrateSensor()
+{
+  // don't for now, these should be properly factory calibrated, any slight error during calibration will introduce more error
+  // fake calibration to get rid of error
+  _calibrationOffset.ax = 1;
+  _calibrationOffset.ay = 0;
+  _calibrationOffset.az = 0;
+  _calibrationOffset.gx = 0;
+  _calibrationOffset.gy = 0;
+  _calibrationOffset.gz = 0;
+
+  myConfig.setGyroCalibration(_calibrationOffset);
+  myConfig.saveFile();
+}
+
+void ICM42670pGyro::debug()
+{
+  // todo
+}
+
+String ICM42670pGyro::getGyroFamily()
+{
+  return "ICM42670-p";
+}
+
+// EOF

--- a/src/MPU6050Gyro.cpp
+++ b/src/MPU6050Gyro.cpp
@@ -1,0 +1,275 @@
+/*
+MIT License
+
+Copyright (c) 2021-2024 Magnus
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
+#include <MPU6050.h>
+
+#include <MPU6050Gyro.hpp>
+#include <log.hpp>
+#include <main.hpp>
+
+MPU6050Gyro mpuGyro;
+MPU6050 accelgyro;
+
+#define GYRO_USE_INTERRUPT  // Use interrupt to detect when new sample is ready
+#define GYRO_SHOW_MINMAX    // Will calculate the min/max values when doing
+                            // calibration
+
+bool MPU6050Gyro::isOnline() {
+  uint8_t id = accelgyro.getDeviceID();
+  return id == 0x34 || id == 0x38;
+}
+
+bool MPU6050Gyro::setup() {
+  accelgyro.initialize();
+  _sensorConnected = true;
+
+  // Configure the sensor
+  accelgyro.setTempSensorEnabled(true);
+  accelgyro.setDLPFMode(MPU6050_DLPF_BW_5);
+#if defined(GYRO_USE_INTERRUPT)
+  // Alternative method to read data, let the MPU signal when sampling is
+  // done.
+  accelgyro.setRate(17);
+  accelgyro.setInterruptDrive(1);
+  accelgyro.setInterruptMode(1);
+  accelgyro.setInterruptLatch(0);
+  accelgyro.setIntDataReadyEnabled(true);
+#endif
+
+  // Once we have calibration values stored we just apply them from the
+  // config.
+  _calibrationOffset = myConfig.getGyroCalibration();
+  applyCalibration();
+  return _sensorConnected;
+}
+
+void MPU6050Gyro::enterSleep() {
+  accelgyro.setSleepEnabled(true);
+}
+
+GyroResultData MPU6050Gyro::readSensor() {
+  int noIterations = myConfig.getGyroReadCount();
+#if !defined(GYRO_USE_INTERRUPT)
+  int delayTime = myConfig.getGyroReadDelay();
+#endif
+  RawGyroDataL average = {0, 0, 0, 0, 0, 0};
+
+  // Set some initial values
+#if defined(GYRO_SHOW_MINMAX)
+  RawGyroData min = {0, 0, 0};
+  RawGyroData max = {0, 0, 0};
+  accelgyro.getAcceleration(&min.ax, &min.ay, &min.az);
+  min.temp = accelgyro.getTemperature();
+  max = min;
+#endif
+  for (int cnt = 0; cnt < noIterations; cnt++) {
+#if defined(GYRO_USE_INTERRUPT)
+    while (accelgyro.getIntDataReadyStatus() == 0) {
+      delayMicroseconds(1);
+    }
+#endif
+
+    accelgyro.getMotion6(&raw.ax, &raw.ay, &raw.az, &raw.gx, &raw.gy, &raw.gz);
+    raw.temp = accelgyro.getTemperature();
+
+    average.ax += raw.ax;
+    average.ay += raw.ay;
+    average.az += raw.az;
+    average.gx += raw.gx;
+    average.gy += raw.gy;
+    average.gz += raw.gz;
+    average.temp += raw.temp;
+
+    // Log what the minium value is
+#if defined(GYRO_SHOW_MINMAX)
+    if (raw.ax < min.ax) min.ax = raw.ax;
+    if (raw.ay < min.ay) min.ay = raw.ay;
+    if (raw.az < min.az) min.az = raw.az;
+    if (raw.gx < min.gx) min.gx = raw.gx;
+    if (raw.gy < min.gy) min.gy = raw.gy;
+    if (raw.gz < min.gz) min.gz = raw.gz;
+    if (raw.temp < min.temp) min.temp = raw.temp;
+
+    // Log what the maximum value is
+    if (raw.ax > max.ax) max.ax = raw.ax;
+    if (raw.ay > max.ay) max.ay = raw.ay;
+    if (raw.az > max.az) max.az = raw.az;
+    if (raw.gx > max.gx) max.gx = raw.gx;
+    if (raw.gy > max.gy) max.gy = raw.gy;
+    if (raw.gz > max.gz) max.gz = raw.gz;
+    if (raw.temp > max.temp) max.temp = raw.temp;
+#endif
+
+#if !defined(GYRO_USE_INTERRUPT)
+    delayMicroseconds(delayTime);
+#endif
+  }
+
+  raw.ax = average.ax / noIterations;
+  raw.ay = average.ay / noIterations;
+  raw.az = average.az / noIterations;
+  raw.gx = average.gx / noIterations;
+  raw.gy = average.gy / noIterations;
+  raw.gz = average.gz / noIterations;
+  raw.temp = average.temp / noIterations;
+
+#if defined(GYRO_SHOW_MINMAX) && LOG_LEVEL == 6
+  Log.verbose(F("GYRO: Min    \t%d\t%d\t%d\t%d\t%d\t%d\t%d." CR), min.ax,
+              min.ay, min.az, min.gx, min.gy, min.gz, min.temp);
+  Log.verbose(F("GYRO: Max    \t%d\t%d\t%d\t%d\t%d\t%d\t%d." CR), max.ax,
+              max.ay, max.az, max.gx, max.gy, max.gz, max.temp);
+#endif
+  GyroResultData result;
+  result.isValid = !isSensorMovingRaw(raw);
+  if (result.isValid)
+  {
+    result.angle = calculateAngleRaw(raw);
+  }
+  result.temp = (static_cast<float>(raw.temp)) / 340 + 36.53;
+  return result;
+}
+
+void MPU6050Gyro::applyCalibration() {
+#if LOG_LEVEL == 6
+  Log.verbose(F("GYRO: Applying calibration offsets to sensor." CR));
+#endif
+
+  if ((_calibrationOffset.ax + _calibrationOffset.ay + _calibrationOffset.az +
+       _calibrationOffset.gx + _calibrationOffset.gy + _calibrationOffset.gz) ==
+      0) {
+    writeErrorLog(
+        "GYRO: No valid calibration values, please calibrate the device.");
+    return;
+  }
+
+  accelgyro.setXAccelOffset(_calibrationOffset.ax);
+  accelgyro.setYAccelOffset(_calibrationOffset.ay);
+  accelgyro.setZAccelOffset(_calibrationOffset.az);
+  accelgyro.setXGyroOffset(_calibrationOffset.gx);
+  accelgyro.setYGyroOffset(_calibrationOffset.gy);
+  accelgyro.setZGyroOffset(_calibrationOffset.gz);
+}
+
+void MPU6050Gyro::calibrateSensor() {
+#if LOG_LEVEL == 6
+  Log.verbose(F("GYRO: Calibrating sensor" CR));
+#endif
+  // accelgyro.PrintActiveOffsets();
+  // EspSerial.print( CR );
+
+  accelgyro.setDLPFMode(MPU6050_DLPF_BW_5);
+  accelgyro.CalibrateAccel(6);  // 6 = 600 readings
+  accelgyro.CalibrateGyro(6);
+
+  accelgyro.PrintActiveOffsets();
+  EspSerial.print(CR);
+
+  _calibrationOffset.ax = accelgyro.getXAccelOffset();
+  _calibrationOffset.ay = accelgyro.getYAccelOffset();
+  _calibrationOffset.az = accelgyro.getZAccelOffset();
+  _calibrationOffset.gx = accelgyro.getXGyroOffset();
+  _calibrationOffset.gy = accelgyro.getYGyroOffset();
+  _calibrationOffset.gz = accelgyro.getZGyroOffset();
+
+  myConfig.setGyroCalibration(_calibrationOffset);
+  myConfig.saveFile();
+}
+
+void MPU6050Gyro::debug() {
+#if LOG_LEVEL == 6
+  Log.verbose(F("GYRO: Debug - Clock src   %d." CR),
+              accelgyro.getClockSource());
+  Log.verbose(F("GYRO: Debug - Device ID   %d." CR), accelgyro.getDeviceID());
+  Log.verbose(F("GYRO: Debug - DHPF Mode   %d." CR), accelgyro.getDHPFMode());
+  Log.verbose(F("GYRO: Debug - DMP on      %s." CR),
+              accelgyro.getDMPEnabled() ? "on" : "off");
+  Log.verbose(F("GYRO: Debug - Acc range   %d." CR),
+              accelgyro.getFullScaleAccelRange());
+  Log.verbose(F("GYRO: Debug - Gyr range   %d." CR),
+              accelgyro.getFullScaleGyroRange());
+  Log.verbose(F("GYRO: Debug - Int         %s." CR),
+              accelgyro.getIntEnabled() ? "on" : "off");
+  Log.verbose(F("GYRO: Debug - Clock       %d." CR),
+              accelgyro.getMasterClockSpeed());
+  Log.verbose(F("GYRO: Debug - Rate        %d." CR), accelgyro.getRate());
+  Log.verbose(F("GYRO: Debug - Gyro range  %d." CR),
+              accelgyro.getFullScaleGyroRange());
+  Log.verbose(F("GYRO: Debug - Acc FactX   %d." CR),
+              accelgyro.getAccelXSelfTestFactoryTrim());
+  Log.verbose(F("GYRO: Debug - Acc FactY   %d." CR),
+              accelgyro.getAccelYSelfTestFactoryTrim());
+  Log.verbose(F("GYRO: Debug - Acc FactZ   %d." CR),
+              accelgyro.getAccelZSelfTestFactoryTrim());
+  Log.verbose(F("GYRO: Debug - Gyr FactX   %d." CR),
+              accelgyro.getGyroXSelfTestFactoryTrim());
+  Log.verbose(F("GYRO: Debug - Gyr FactY   %d." CR),
+              accelgyro.getGyroYSelfTestFactoryTrim());
+  Log.verbose(F("GYRO: Debug - Gyr FactZ   %d." CR),
+              accelgyro.getGyroZSelfTestFactoryTrim());
+
+  switch (accelgyro.getFullScaleAccelRange()) {
+    case 0:
+      Log.verbose(F("GYRO: Debug - Accel range +/- 2g." CR));
+      break;
+    case 1:
+      Log.verbose(F("GYRO: Debug - Accel range +/- 4g." CR));
+      break;
+    case 2:
+      Log.verbose(F("GYRO: Debug - Accel range +/- 8g." CR));
+      break;
+    case 3:
+      Log.verbose(F("GYRO: Debug - Accel range +/- 16g." CR));
+      break;
+  }
+
+  Log.verbose(F("GYRO: Debug - Acc OffX    %d\t%d." CR),
+              accelgyro.getXAccelOffset(), _calibrationOffset.az);
+  Log.verbose(F("GYRO: Debug - Acc OffY    %d\t%d." CR),
+              accelgyro.getYAccelOffset(), _calibrationOffset.ay);
+  Log.verbose(F("GYRO: Debug - Acc OffZ    %d\t%d." CR),
+              accelgyro.getZAccelOffset(), _calibrationOffset.az);
+  Log.verbose(F("GYRO: Debug - Gyr OffX    %d\t%d." CR),
+              accelgyro.getXGyroOffset(), _calibrationOffset.gx);
+  Log.verbose(F("GYRO: Debug - Gyr OffY    %d\t%d." CR),
+              accelgyro.getYGyroOffset(), _calibrationOffset.gy);
+  Log.verbose(F("GYRO: Debug - Gyr OffZ    %d\t%d." CR),
+              accelgyro.getZGyroOffset(), _calibrationOffset.gz);
+#endif
+}
+
+  String MPU6050Gyro::getGyroFamily(){
+    auto id = accelgyro.getDeviceID();// if not connected this can return a random byte
+    switch (id) {
+      case 0x34:
+        return "MPU6050";
+        break;
+      case 0x38:
+        return  "MPU6500";
+        break;
+      default:
+        return  "0x" + String(id, 16);
+        break;
+    }
+  }
+
+// EOF

--- a/src/MPU6050Gyro.hpp
+++ b/src/MPU6050Gyro.hpp
@@ -21,38 +21,28 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
  */
-#include <battery.hpp>
-#include <config.hpp>
-#include <main.hpp>
+#ifndef SRC_MPUGYRO_HPP_
+#define SRC_MPUGYRO_HPP_
 
-BatteryVoltage::BatteryVoltage() {
-#if defined(ESP8266) || defined(ESP32S2)
-  pinMode(myConfig.getVoltagePin(), INPUT);
-#else
-  pinMode(myConfig.getVoltagePin(), INPUT_PULLDOWN);
-#endif
-}
+#include <gyro.hpp>
 
-void BatteryVoltage::read() {
-  // The analog pin can only handle 3.3V maximum voltage so we need to reduce
-  // the voltage (from max 5V)
-  float factor = myConfig.getVoltageFactor();  // Default value is 1.63
-  int v = analogRead(myConfig.getVoltagePin());
+class MPU6050Gyro : public GyroSensor {
+ private:
+  RawGyroData raw;
+  void debug();
+  void applyCalibration();
+  GyroResultData readSensor();
 
-  // An ESP8266 has a ADC range of 0-1023 and a maximum voltage of 3.3V
-  // An ESP32 has an ADC range of 0-4095 and a maximum voltage of 3.3V
+ public:
+  bool isOnline();
+  bool setup();
+  void calibrateSensor();
+  String getGyroFamily();
+  void enterSleep();
+};
 
-#if defined(ESP8266)
-  _batteryLevel = ((3.3 / 1023) * v) * factor;
-#elif defined(ESP32S2)
-  _batteryLevel = ((2.5 / 8191) * v) * factor;
-#else  // defined (ESP32)
-  _batteryLevel = ((3.3 / 4095) * v) * factor;
-#endif
-#if LOG_LEVEL == 6
-  Log.verbose(
-      F("BATT: Reading voltage level. Factor=%F Value=%d, Voltage=%F." CR),
-      factor, v, _batteryLevel);
-#endif
-}
+extern MPU6050Gyro mpuGyro;
+
+#endif  // SRC_MPUGYRO_HPP_
+
 // EOF

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -49,6 +49,13 @@ struct RawGyroData {
   int16_t temp;  // Only for information (temperature of chip)
 };
 
+// Used for holding result data
+struct GyroResultData {
+  bool isValid;
+  float angle;
+  float temp;
+};
+
 // Used for holding formulaData (used for calculating formula on device)
 #define FORMULA_DATA_SIZE 20
 
@@ -178,7 +185,7 @@ class GravmonConfig : public BaseConfig {
     _saveNeeded = true;
   }
 
-  int getSleepInterval() { return _sleepInterval; }
+  const int getSleepInterval() const { return _sleepInterval; }
   void setSleepInterval(int v) {
     _sleepInterval = v;
     _saveNeeded = true;

--- a/src/gyro.cpp
+++ b/src/gyro.cpp
@@ -27,177 +27,9 @@ SOFTWARE.
 #include <log.hpp>
 #include <main.hpp>
 
-GyroSensor myGyro;
-MPU6050 accelgyro;
+GyroSensor* myGyro = &mpuGyro;
 
-#define GYRO_USE_INTERRUPT  // Use interrupt to detect when new sample is ready
-#define GYRO_SHOW_MINMAX    // Will calculate the min/max values when doing
-                            // calibration
-
-uint8_t GyroSensor::getGyroID() { return accelgyro.getDeviceID(); }
-
-bool GyroSensor::setup() {
-  int clock = 400000;
-#if defined(FLOATY)
-  pinMode(PIN_VCC, OUTPUT);
-  pinMode(PIN_GND, OUTPUT_OPEN_DRAIN);
-  digitalWrite(PIN_VCC, HIGH);
-  digitalWrite(PIN_GND, LOW);
-  delay(10);  // Wait for the pins to settle or we will fail to connect
-#else
-#endif
-  /* For testing pin config of new boards with led.
-  pinMode(PIN_SDA, OUTPUT);
-  pinMode(PIN_SCL, OUTPUT);
-  for(int i = 0, j = LOW, k = LOW; i < 100; i++) {
-
-    digitalWrite(PIN_SDA, k);
-    digitalWrite(PIN_SCL, j);
-    k = !k;
-    delay(300);
-    digitalWrite(PIN_SDA, k);
-    k = !k;
-    j = !j;
-    delay(300);
-  }*/
-
-#if LOG_LEVEL == 6
-  Log.verbose(F("GYRO: Setting up hardware." CR));
-#endif
-  Wire.begin(PIN_SDA, PIN_SCL);
-  Wire.setClock(clock);  // 400kHz I2C clock.
-
-  uint8_t id = accelgyro.getDeviceID();
-
-  if (id != 0x34 && id != 0x38) {  // Allow both MPU6050 and MPU6500
-    writeErrorLog("GYRO: Failed to connect to gyro, is it connected?");
-    _sensorConnected = false;
-  } else {
-#if LOG_LEVEL == 6
-    Log.notice(F("GYRO: Connected to MPU6050 (gyro)." CR));
-#endif
-    accelgyro.initialize();
-    _sensorConnected = true;
-
-    // Configure the sensor
-    accelgyro.setTempSensorEnabled(true);
-    accelgyro.setDLPFMode(MPU6050_DLPF_BW_5);
-#if defined(GYRO_USE_INTERRUPT)
-    // Alternative method to read data, let the MPU signal when sampling is
-    // done.
-    accelgyro.setRate(17);
-    accelgyro.setInterruptDrive(1);
-    accelgyro.setInterruptMode(1);
-    accelgyro.setInterruptLatch(0);
-    accelgyro.setIntDataReadyEnabled(true);
-#endif
-
-    // Once we have calibration values stored we just apply them from the
-    // config.
-    _calibrationOffset = myConfig.getGyroCalibration();
-    applyCalibration();
-  }
-  return _sensorConnected;
-}
-
-void GyroSensor::enterSleep() {
-#if LOG_LEVEL == 6
-  Log.verbose(F("GYRO: Setting up hardware." CR));
-#endif
-#if defined(FLOATY)
-  digitalWrite(PIN_VCC, LOW);
-#else
-  accelgyro.setSleepEnabled(true);
-#endif
-}
-
-void GyroSensor::readSensor(RawGyroData &raw, const int noIterations,
-                            const int delayTime) {
-  RawGyroDataL average = {0, 0, 0, 0, 0, 0};
-
-#if LOG_LEVEL == 6
-  Log.verbose(F("GYRO: Reading sensor with %d iterations %d us delay." CR),
-              noIterations, delayTime);
-#endif
-
-  // Set some initial values
-#if defined(GYRO_SHOW_MINMAX)
-  RawGyroData min = {0, 0, 0};
-  RawGyroData max = {0, 0, 0};
-  accelgyro.getAcceleration(&min.ax, &min.ay, &min.az);
-  min.temp = accelgyro.getTemperature();
-  max = min;
-#endif
-  for (int cnt = 0; cnt < noIterations; cnt++) {
-#if defined(GYRO_USE_INTERRUPT)
-    while (accelgyro.getIntDataReadyStatus() == 0) {
-      delayMicroseconds(1);
-    }
-#endif
-
-    accelgyro.getMotion6(&raw.ax, &raw.ay, &raw.az, &raw.gx, &raw.gy, &raw.gz);
-    raw.temp = accelgyro.getTemperature();
-
-    average.ax += raw.ax;
-    average.ay += raw.ay;
-    average.az += raw.az;
-    average.gx += raw.gx;
-    average.gy += raw.gy;
-    average.gz += raw.gz;
-    average.temp += raw.temp;
-
-    // Log what the minium value is
-#if defined(GYRO_SHOW_MINMAX)
-    if (raw.ax < min.ax) min.ax = raw.ax;
-    if (raw.ay < min.ay) min.ay = raw.ay;
-    if (raw.az < min.az) min.az = raw.az;
-    if (raw.gx < min.gx) min.gx = raw.gx;
-    if (raw.gy < min.gy) min.gy = raw.gy;
-    if (raw.gz < min.gz) min.gz = raw.gz;
-    if (raw.temp < min.temp) min.temp = raw.temp;
-
-    // Log what the maximum value is
-    if (raw.ax > max.ax) max.ax = raw.ax;
-    if (raw.ay > max.ay) max.ay = raw.ay;
-    if (raw.az > max.az) max.az = raw.az;
-    if (raw.gx > max.gx) max.gx = raw.gx;
-    if (raw.gy > max.gy) max.gy = raw.gy;
-    if (raw.gz > max.gz) max.gz = raw.gz;
-    if (raw.temp > max.temp) max.temp = raw.temp;
-#endif
-
-#if !defined(GYRO_USE_INTERRUPT)
-    delayMicroseconds(delayTime);
-#endif
-  }
-
-  raw.ax = average.ax / noIterations;
-  raw.ay = average.ay / noIterations;
-  raw.az = average.az / noIterations;
-  raw.gx = average.gx / noIterations;
-  raw.gy = average.gy / noIterations;
-  raw.gz = average.gz / noIterations;
-  raw.temp = average.temp / noIterations;
-
-#if LOG_LEVEL == 6
-#if defined(GYRO_SHOW_MINMAX)
-  Log.verbose(F("GYRO: Min    \t%d\t%d\t%d\t%d\t%d\t%d\t%d." CR), min.ax,
-              min.ay, min.az, min.gx, min.gy, min.gz, min.temp);
-  Log.verbose(F("GYRO: Max    \t%d\t%d\t%d\t%d\t%d\t%d\t%d." CR), max.ax,
-              max.ay, max.az, max.gx, max.gy, max.gz, max.temp);
-#endif
-  Log.verbose(F("GYRO: Average\t%d\t%d\t%d\t%d\t%d\t%d\t%d." CR), raw.ax,
-              raw.ay, raw.az, raw.gx, raw.gy, raw.gz, raw.temp);
-  // Log.verbose(F("GYRO: Result \t%d\t%d\t%d\t%d\t%d\t%d." CR),
-  // average.ax/noIterations, average.ay/noIterations, average.az/noIterations,
-  //                                                             average.gx/noIterations,
-  //                                                             average.gy/noIterations,
-  //                                                             average.gz/noIterations
-  //                                                             );
-#endif
-}
-
-float GyroSensor::calculateAngle(RawGyroData &raw) {
+float GyroSensor::calculateAngleRaw(RawGyroData &raw) {
 #if LOG_LEVEL == 6
   Log.verbose(F("GYRO: Calculating the angle." CR));
 #endif
@@ -211,11 +43,7 @@ float GyroSensor::calculateAngle(RawGyroData &raw) {
         ay = (static_cast<float>(raw.ay)) / 16384,
         az = (static_cast<float>(raw.az)) / 16384;
 
-  // Source: https://www.nxp.com/docs/en/application-note/AN3461.pdf
-  float vY = (acos(abs(ay) / sqrt(ax * ax + ay * ay + az * az)) * 180.0 / PI);
-  // float vZ = (acos(abs(az) / sqrt(ax * ax + ay * ay + az * az)) * 180.0 /
-  // PI); float vX = (acos(abs(ax) / sqrt(ax * ax + ay * ay + az * az)) * 180.0
-  // / PI);
+  float vY = calculateAngle(ax, ay, az);
 #if LOG_LEVEL == 6
   // Log.notice(F("GYRO: angleX= %F." CR), vX);
   Log.notice(F("GYRO: angleY= %F." CR), vY);
@@ -224,22 +52,38 @@ float GyroSensor::calculateAngle(RawGyroData &raw) {
   return vY;
 }
 
-bool GyroSensor::isSensorMoving(RawGyroData &raw) {
+float GyroSensor::calculateAngle(float ax, float ay, float az) {
+  // Source: https://www.nxp.com/docs/en/application-note/AN3461.pdf
+  float vY = (acos(abs(ay) / sqrt(ax * ax + ay * ay + az * az)) * 180.0 / PI);
+  // float vZ = (acos(abs(az) / sqrt(ax * ax + ay * ay + az * az)) * 180.0 /
+  // PI); float vX = (acos(abs(ax) / sqrt(ax * ax + ay * ay + az * az)) * 180.0
+  // / PI);
+  return vY;
+}
+
+bool GyroSensor::isSensorMovingRaw(RawGyroData &raw) {
 #if LOG_LEVEL == 6
   Log.verbose(F("GYRO: Checking for sensor movement." CR));
 #endif
 
   int x = abs(raw.gx), y = abs(raw.gy), z = abs(raw.gz);
   int threashold = myConfig.getGyroSensorMovingThreashold();
-  _sensorMoving = false;
 
   if (x > threashold || y > threashold || z > threashold) {
     Log.notice(F("GYRO: Movement detected (%d)\t%d\t%d\t%d." CR), threashold, x,
                y, z);
-    _sensorMoving = true;
+    return true;
   }
 
-  return _sensorMoving;
+  return false;
+}
+
+bool GyroSensor::isSensorMoving(int16_t gx, int16_t gy, int16_t gz) {
+  int x = abs(gx), y = abs(gy), z = abs(gz);
+  int threashold = myConfig.getGyroSensorMovingThreashold();
+    // Log.notice(F("GYRO: Movement (%d)\t%d\t%d\t%d." CR), threashold, x,
+    //            y, z);
+  return x > threashold || y > threashold || z > threashold;
 }
 
 bool GyroSensor::read() {
@@ -249,27 +93,36 @@ bool GyroSensor::read() {
 
   if (!_sensorConnected) return false;
 
-  readSensor(_lastGyroData, myConfig.getGyroReadCount(),
-             myConfig.getGyroReadDelay());  // Last param is unused if
-                                            // GYRO_USE_INTERRUPT is defined.
+#if LOG_LEVEL == 6
+  Log.verbose(F("GYRO: Reading sensor with %d iterations %d us delay." CR),
+              noIterations, delayTime);
+#endif
+
+  auto result = readSensor();
+
+#if LOG_LEVEL == 6
+  Log.verbose(F("GYRO: Average\t%d\t%d\t%d\t%d\t%d\t%d\t%d." CR), _lastGyroData.ax,
+              _lastGyroData.ay, _lastGyroData.az, _lastGyroData.gx, _lastGyroData.gy,
+              _lastGyroData.gz, _lastGyroData.temp);
+#endif
 
   // If the sensor is unstable we return false to signal we dont have valid
   // value
-  if (isSensorMoving(_lastGyroData)) {
-#if LOG_LEVEL == 6
-    Log.notice(F("GYRO: Sensor is moving." CR));
-#endif
-    _validValue = false;
-  } else {
+  if (result.isValid) {
     _validValue = true;
-    _angle = calculateAngle(_lastGyroData);
+    _angle = result.angle;
 #if LOG_LEVEL == 6
     Log.verbose(F("GYRO: Sensor values %d,%d,%d\t%F" CR), _lastGyroData.ax,
                 _lastGyroData.ay, _lastGyroData.az, _angle);
 #endif
+  } else {
+#if LOG_LEVEL == 6
+    Log.notice(F("GYRO: Sensor is moving." CR));
+#endif
+    _validValue = false;
   }
 
-  _sensorTemp = (static_cast<float>(_lastGyroData.temp)) / 340 + 36.53;
+  _sensorTemp = result.temp;
 
   // The first read value is close to the DS18 value according to my tests, if
   // more reads are done then the gyro temp will increase to much
@@ -285,114 +138,6 @@ void GyroSensor::dumpCalibration() {
               _calibrationOffset.ay, _calibrationOffset.az);
   Log.verbose(F("GYRO: Gyro offset \t%d\t%d\t%d" CR), _calibrationOffset.gx,
               _calibrationOffset.gy, _calibrationOffset.gz);
-#endif
-}
-
-void GyroSensor::applyCalibration() {
-#if LOG_LEVEL == 6
-  Log.verbose(F("GYRO: Applying calibration offsets to sensor." CR));
-#endif
-
-  if ((_calibrationOffset.ax + _calibrationOffset.ay + _calibrationOffset.az +
-       _calibrationOffset.gx + _calibrationOffset.gy + _calibrationOffset.gz) ==
-      0) {
-    writeErrorLog(
-        "GYRO: No valid calibration values, please calibrate the device.");
-    return;
-  }
-
-  accelgyro.setXAccelOffset(_calibrationOffset.ax);
-  accelgyro.setYAccelOffset(_calibrationOffset.ay);
-  accelgyro.setZAccelOffset(_calibrationOffset.az);
-  accelgyro.setXGyroOffset(_calibrationOffset.gx);
-  accelgyro.setYGyroOffset(_calibrationOffset.gy);
-  accelgyro.setZGyroOffset(_calibrationOffset.gz);
-}
-
-void GyroSensor::calibrateSensor() {
-#if LOG_LEVEL == 6
-  Log.verbose(F("GYRO: Calibrating sensor" CR));
-#endif
-  // accelgyro.PrintActiveOffsets();
-  // EspSerial.print( CR );
-
-  accelgyro.setDLPFMode(MPU6050_DLPF_BW_5);
-  accelgyro.CalibrateAccel(6);  // 6 = 600 readings
-  accelgyro.CalibrateGyro(6);
-
-  accelgyro.PrintActiveOffsets();
-  EspSerial.print(CR);
-
-  _calibrationOffset.ax = accelgyro.getXAccelOffset();
-  _calibrationOffset.ay = accelgyro.getYAccelOffset();
-  _calibrationOffset.az = accelgyro.getZAccelOffset();
-  _calibrationOffset.gx = accelgyro.getXGyroOffset();
-  _calibrationOffset.gy = accelgyro.getYGyroOffset();
-  _calibrationOffset.gz = accelgyro.getZGyroOffset();
-
-  myConfig.setGyroCalibration(_calibrationOffset);
-  myConfig.saveFile();
-}
-
-void GyroSensor::debug() {
-#if LOG_LEVEL == 6
-  Log.verbose(F("GYRO: Debug - Clock src   %d." CR),
-              accelgyro.getClockSource());
-  Log.verbose(F("GYRO: Debug - Device ID   %d." CR), accelgyro.getDeviceID());
-  Log.verbose(F("GYRO: Debug - DHPF Mode   %d." CR), accelgyro.getDHPFMode());
-  Log.verbose(F("GYRO: Debug - DMP on      %s." CR),
-              accelgyro.getDMPEnabled() ? "on" : "off");
-  Log.verbose(F("GYRO: Debug - Acc range   %d." CR),
-              accelgyro.getFullScaleAccelRange());
-  Log.verbose(F("GYRO: Debug - Gyr range   %d." CR),
-              accelgyro.getFullScaleGyroRange());
-  Log.verbose(F("GYRO: Debug - Int         %s." CR),
-              accelgyro.getIntEnabled() ? "on" : "off");
-  Log.verbose(F("GYRO: Debug - Clock       %d." CR),
-              accelgyro.getMasterClockSpeed());
-  Log.verbose(F("GYRO: Debug - Rate        %d." CR), accelgyro.getRate());
-  Log.verbose(F("GYRO: Debug - Gyro range  %d." CR),
-              accelgyro.getFullScaleGyroRange());
-  Log.verbose(F("GYRO: Debug - Acc FactX   %d." CR),
-              accelgyro.getAccelXSelfTestFactoryTrim());
-  Log.verbose(F("GYRO: Debug - Acc FactY   %d." CR),
-              accelgyro.getAccelYSelfTestFactoryTrim());
-  Log.verbose(F("GYRO: Debug - Acc FactZ   %d." CR),
-              accelgyro.getAccelZSelfTestFactoryTrim());
-  Log.verbose(F("GYRO: Debug - Gyr FactX   %d." CR),
-              accelgyro.getGyroXSelfTestFactoryTrim());
-  Log.verbose(F("GYRO: Debug - Gyr FactY   %d." CR),
-              accelgyro.getGyroYSelfTestFactoryTrim());
-  Log.verbose(F("GYRO: Debug - Gyr FactZ   %d." CR),
-              accelgyro.getGyroZSelfTestFactoryTrim());
-
-  switch (accelgyro.getFullScaleAccelRange()) {
-    case 0:
-      Log.verbose(F("GYRO: Debug - Accel range +/- 2g." CR));
-      break;
-    case 1:
-      Log.verbose(F("GYRO: Debug - Accel range +/- 4g." CR));
-      break;
-    case 2:
-      Log.verbose(F("GYRO: Debug - Accel range +/- 8g." CR));
-      break;
-    case 3:
-      Log.verbose(F("GYRO: Debug - Accel range +/- 16g." CR));
-      break;
-  }
-
-  Log.verbose(F("GYRO: Debug - Acc OffX    %d\t%d." CR),
-              accelgyro.getXAccelOffset(), _calibrationOffset.az);
-  Log.verbose(F("GYRO: Debug - Acc OffY    %d\t%d." CR),
-              accelgyro.getYAccelOffset(), _calibrationOffset.ay);
-  Log.verbose(F("GYRO: Debug - Acc OffZ    %d\t%d." CR),
-              accelgyro.getZAccelOffset(), _calibrationOffset.az);
-  Log.verbose(F("GYRO: Debug - Gyr OffX    %d\t%d." CR),
-              accelgyro.getXGyroOffset(), _calibrationOffset.gx);
-  Log.verbose(F("GYRO: Debug - Gyr OffY    %d\t%d." CR),
-              accelgyro.getYGyroOffset(), _calibrationOffset.gy);
-  Log.verbose(F("GYRO: Debug - Gyr OffZ    %d\t%d." CR),
-              accelgyro.getZGyroOffset(), _calibrationOffset.gz);
 #endif
 }
 

--- a/src/gyro.hpp
+++ b/src/gyro.hpp
@@ -24,9 +24,6 @@ SOFTWARE.
 #ifndef SRC_GYRO_HPP_
 #define SRC_GYRO_HPP_
 
-#define I2CDEV_IMPLEMENTATION I2CDEV_ARDUINO_WIRE
-// #define I2CDEV_IMPLEMENTATION I2CDEV_BUILTIN_SBWIRE
-
 #include <config.hpp>
 
 struct RawGyroDataL {  // Used for average multiple readings
@@ -44,41 +41,45 @@ struct RawGyroDataL {  // Used for average multiple readings
 #define INVALID_TEMPERATURE -273
 
 class GyroSensor {
- private:
+protected:
   bool _sensorConnected = false;
   bool _validValue = false;
   float _angle = 0;
-  float _sensorTemp = 0;
+  float _sensorTemp = INVALID_TEMPERATURE;
   float _initialSensorTemp = INVALID_TEMPERATURE;
   RawGyroData _calibrationOffset;
-  RawGyroData _lastGyroData;
-  bool _sensorMoving = false;
 
-  void debug();
-  void applyCalibration();
   void dumpCalibration();
-  void readSensor(RawGyroData &raw, const int noIterations = 100,
-                  const int delayTime = 1);
-  bool isSensorMoving(RawGyroData &raw);
-  float calculateAngle(RawGyroData &raw);
+  bool isSensorMoving(int16_t gx, int16_t gy, int16_t gz);
+  bool isSensorMovingRaw(RawGyroData &raw);
+  float calculateAngle(float ax, float ay, float az);
+  float calculateAngleRaw(RawGyroData &raw);
 
- public:
-  bool setup();
+//virtual to be implemented by gyro
+  virtual void debug() = 0;
+  virtual void applyCalibration() = 0;
+  virtual GyroResultData readSensor() = 0;
+
+public:
   bool read();
-  void calibrateSensor();
-  uint8_t getGyroID();
-  bool isSensorMoving() { return _sensorMoving; }
-
-  const RawGyroData &getLastGyroData() { return _lastGyroData; }
   float getAngle() { return _angle; }
   float getSensorTempC() { return _sensorTemp; }
   float getInitialSensorTempC() { return _initialSensorTemp; }
   bool isConnected() { return _sensorConnected; }
   bool hasValue() { return _validValue; }
-  void enterSleep();
+
+//virtual to be implemented by gyro
+  virtual bool isOnline() = 0;
+  virtual bool setup() = 0;
+  virtual void calibrateSensor() = 0;
+  virtual String getGyroFamily() = 0;
+  virtual void enterSleep() = 0;
 };
 
-extern GyroSensor myGyro;
+#include <MPU6050Gyro.hpp>
+#include <ICM42670pGyro.hpp>
+
+extern GyroSensor* myGyro;
 
 #endif  // SRC_GYRO_HPP_
 

--- a/src/tempsensor.cpp
+++ b/src/tempsensor.cpp
@@ -61,7 +61,7 @@ void TempSensor::readSensor(bool useGyro) {
   if (useGyro) {
     // When using the gyro temperature only the first read value will be
     // accurate so we will use this for processing.
-    _temperatureC = myGyro.getInitialSensorTempC();
+    _temperatureC = myGyro->getInitialSensorTempC();
     _hasSensor = true;
 #if LOG_LEVEL == 6
     Log.verbose(F("TSEN: Reciving temp value for gyro sensor %F C." CR),


### PR DESCRIPTION
Full changelog:
- Preparation for multi IMU support
- Moved IMU specific methods to child class
- Kept IMU agnostic methods and fields in base class
- Changed myGyro static instance to a pointer type
- Changed all references to use the pointer
- Assigned new MPU6050 instance as default to the pointer
- Added online check for IMU without erroring
- Moved shared Wire setup to main
- Separated online check from setup
- Added basic ICM42670p support
- Fix issues found while testing
- Optimize setup time and ready time
- Implemented ICM42670p FIFO mode
- Created new object to return results in float format
- Created new helper methods of angle conversion and movement detection without logging
- Removed redundant readSensor arguments
- Fix ICM calibration warning not going away
- Fix issue with empty fifo not being seen as invalid data
- Fix battery level for S2 board

I do not recommend merging just yet as i have not tested after the merge, it compiles but might not work. Also we need to figure out if we want to dynamically allocate the imus or keep it as is. RAM might also be optimized more by removing some cache fields and just fetching the data when you actually need it.
